### PR TITLE
manage app state

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -3,7 +3,7 @@ import { DrizzleContext } from "@drizzle/react-plugin";
 import { Drizzle } from "@drizzle/store";
 import drizzleOptions from "./drizzleOptions";
 import "./App.css";
-import Router from "./router/Router"
+import State from "./state/AppState"
 
 const drizzle = new Drizzle(drizzleOptions);
 
@@ -15,7 +15,7 @@ const App = () => {
           const { drizzle, drizzleState, initialized } = drizzleContext;
 
           return (
-            initialized ? <Router drizzle={drizzle} drizzleState={drizzleState} /> : "Loading . . ."
+            initialized ? <State drizzle={drizzle} drizzleState={drizzleState} /> : "Loading . . ."
           )
         }}
       </DrizzleContext.Consumer>

--- a/app/src/pages/Home.js
+++ b/app/src/pages/Home.js
@@ -1,18 +1,10 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import Logic from './FundMe'
 
-const Home = ({ drizzle, drizzleState }) => {
+const Home = ({ appState, drizzle, drizzleState }) => {
 
-  const [state, setState] = useState({
-    funderCountHash: null,
-  })
-
-  const fundersCount = state.funderCountHash && drizzleState.contracts.PleaseFundMe.fundersCount[state.funderCountHash]?.value
-  
-  useEffect(() => {
-    const txHash = drizzle.contracts.PleaseFundMe.methods.fundersCount.cacheCall()
-    setState({ funderCountHash: txHash})
-  }, [])
+  const { funderCountHash } = appState
+  const fundersCount = funderCountHash && drizzleState.contracts.PleaseFundMe.fundersCount[funderCountHash]?.value
  
   return(
     <div>

--- a/app/src/router/Router.js
+++ b/app/src/router/Router.js
@@ -12,22 +12,22 @@ import SingleFund from '../pages/SingleFund'
 import CreateFund from '../pages/CreateFund'
 import Logic from '../pages/FundMe'
 
-function Router({ drizzle, drizzleState }) {
+function Router({ appState, setApp, drizzle, drizzleState }) {
   return (
     <div className="App">
       <HashRouter>
         <NavigationBar/>
         
         <Route exact path="/">
-          <Home drizzle={drizzle} drizzleState={drizzleState}/>
+          <Home appState={appState} drizzle={drizzle} drizzleState={drizzleState}/>
         </Route>
         <Route path="/about" component={About}/>
         <Route exact path="/pages" component={ViewFunds}/>
         <Route path="/pages/:id">
-          <SingleFund drizzle={drizzle} drizzleState={drizzleState} />
+          <SingleFund appState={appState} drizzle={drizzle} drizzleState={drizzleState} />
         </Route>
         <Route path="/create" component={CreateFund}>
-          <CreateFund drizzle={drizzle} drizzleState={drizzleState}/>
+          <CreateFund appState={appState} drizzle={drizzle} drizzleState={drizzleState}/>
         </Route>
         <Route path="/logic" >
           <Logic drizzle={drizzle} drizzleState={drizzleState} />

--- a/app/src/state/AppState.js
+++ b/app/src/state/AppState.js
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react'
+import Router from '../router/Router'
+
+const AppState = ({ drizzle, drizzleState }) => {
+
+  const [appState, setAppState] = useState({
+    funderCountHash: null,
+  })
+
+  
+  useEffect(() => {
+    const txHash = drizzle.contracts.PleaseFundMe.methods.fundersCount.cacheCall()
+    setAppState({ funderCountHash: txHash})
+  }, [])
+ 
+  return(
+    <div>
+      <Router appState={appState} setApp={setAppState} drizzle={drizzle} drizzleState={drizzleState} />
+    </div>
+  )
+}
+
+export default AppState


### PR DESCRIPTION
Created `<AppState />` component to manage global app state. Renders `<Router />` with props `appState` and `setApp`

Home now accesses the value of `fundersCount` from `drizzleState` using the `fundersCountHash` from `appState`