### PR TITLE
feat(onboarding): detect metamask and onboard instructions

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -1,29 +1,47 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { DrizzleContext } from '@drizzle/react-plugin';
 import { Drizzle } from '@drizzle/store';
 import drizzleOptions from './drizzleOptions';
 import './App.scss';
 import State from './state/AppState';
+import Home from './pages/Home/Home';
 import store from './middleware';
 
 const drizzle = new Drizzle(drizzleOptions, store);
 
 const App = () => {
-  return (
+  useEffect(() => {
+    const loadMetamask = async () => {
+      const metamask = window.ethereum;
+      await metamask.enable();
+      metamask.on('accountsChanged', (accounts) => {
+        window.location.reload();
+      });
+      metamask.on('networkChanged', (networkId) => {
+        window.location.reload();
+      });
+    };
+    window.ethereum && loadMetamask();
+  }, [])
+  return window.ethereum ? (
     <DrizzleContext.Provider drizzle={drizzle}>
       <DrizzleContext.Consumer>
         {(drizzleContext) => {
           const { drizzle, drizzleState, initialized } = drizzleContext;
 
           return initialized ? (
-            <State drizzle={drizzle} drizzleState={drizzleState} />
+            <State
+              drizzle={drizzle}
+              drizzleState={drizzleState}
+              networkId={window.ethereum.networkVersion}
+            />
           ) : (
-            'Loading . . .'
+            "Loading App . . ."
           );
         }}
       </DrizzleContext.Consumer>
     </DrizzleContext.Provider>
-  );
+  ) : <Home />;
 };
 
 export default App;

--- a/app/src/drizzleOptions.js
+++ b/app/src/drizzleOptions.js
@@ -1,8 +1,6 @@
 import Web3 from 'web3';
 import PleaseFundMe from './contracts/PleaseFundMe.json';
 
-window.ethereum.enable();
-
 const options = {
   web3: {
     block: false,

--- a/app/src/pages/Home/Home.js
+++ b/app/src/pages/Home/Home.js
@@ -1,12 +1,37 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import './Home.scss';
 
 const Home = () => {
+  useEffect(() => {
+    !window.ethereum && alert('please connect to metamask to begin')
+  }, [])
   return (
-    <div>
+    <div className='onboarding-home'>
       <h1>Home</h1>
-      <p>Welcome to Please Fund Me</p>
+      <div className='welcome-container'>
+        <p>Welcome to Please Fund Me, a decentralized crowdfunding application on the blockchain</p>
+      </div>
+      <p>You will need Metamask or another web3 wallet to begin:</p>
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/ZIGUC9JAAw8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+      <div className='matic-container'>
+        <p>You also have to connect to the polygon/matic network:</p>        
+      </div>
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/arQbnikiooA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      <p>
+        go to your metamask network tab and select "custom rpc"
+      </p>
+      <p>enter the following information:</p>
+      <div className='custom-rpc-container'>
+        <p>Network Name: Matic Mainnet</p>
+        <p>New RPC URL: https://rpc-mainnet.matic.network</p>
+        <p>Chain ID: 137</p>
+        <p>Currency Symbol: MATIC</p>
+        <p>Block Explorer URL: https://explorer.matic.network/</p>
+      </div>
+      <p>You can get matic tokens for gas fees here: <a href='https://matic.supply/' target='_blank'>https://matic.supply/</a></p>
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/ePRmAa4oHug?start=70" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
   );
 };
-
 export default Home;

--- a/app/src/pages/Home/Home.scss
+++ b/app/src/pages/Home/Home.scss
@@ -1,0 +1,29 @@
+.onboarding-home {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  h1 {
+    font-size: 22px;
+  }
+  h2 {
+    font-size: 18px;
+    margin-top: 0;
+  }  
+}
+
+.welcome-container {
+  max-width: 500px;
+}
+
+.matic-container {
+  max-width: 500px;
+}
+
+.custom-rpc-container {
+  text-align: left;
+}
+
+.connect-wallet {
+  background-color: blue;
+}

--- a/app/src/pages/UserHome/UserHome.js
+++ b/app/src/pages/UserHome/UserHome.js
@@ -27,12 +27,12 @@ const UserHome = ({ appState, drizzle, drizzleState, match }) => {
   };
 
   useEffect(() => {
-    const accountIdHash = drizzle.contracts.PleaseFundMe.methods.getAccountById.cacheCall(
+    const accountIdHash = drizzle.contracts.PleaseFundMe?.methods.getAccountById.cacheCall(
       userId,
     );
     getUserFriends();
     setState({ accountIdHash });
-  }, [userId, drizzle.contracts.PleaseFundMe.methods.getAccountById]);
+  }, [userId]);
 
   const user = useMemo(() => {
     return (
@@ -52,7 +52,7 @@ const UserHome = ({ appState, drizzle, drizzleState, match }) => {
       ...prevState,
       userFundersHash,
     }));
-  }, [user, drizzle.contracts.PleaseFundMe.methods.getUserFunders]);
+  }, [user]);
 
   const addFriend = () => {
     drizzle.contracts.PleaseFundMe.methods.addFriend.cacheSend(userId);
@@ -120,7 +120,7 @@ const UserHome = ({ appState, drizzle, drizzleState, match }) => {
           ))}
       </div>
     </div>
-  ) : null;
+  ) : "Loading . . .";
 };
 
 export default withRouter(UserHome);

--- a/app/src/state/AppState.js
+++ b/app/src/state/AppState.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import Router from '../router/Router';
 
-const AppState = ({ drizzle, drizzleState }) => {
+const AppState = ({ drizzle, drizzleState, networkId }) => {
   const [appState, setAppState] = useState({
     getAccountsHash: null,
     userId: null,
     userFriends: [],
+    networkId,
   });
 
   const getUserData = async () => {
@@ -19,10 +20,10 @@ const AppState = ({ drizzle, drizzleState }) => {
   };
 
   useEffect(() => {
-    const getAccountsHash = drizzle.contracts.PleaseFundMe.methods.getAccounts.cacheCall();
+    const getAccountsHash = drizzle.contracts.PleaseFundMe?.methods.getAccounts.cacheCall();
     getUserData();
-    setAppState({ getAccountsHash });
-  }, [drizzle.contracts.PleaseFundMe.methods.getAccounts]);
+    setAppState((prevState) => ({ ...prevState, getAccountsHash }));
+  }, []);
 
   return (
     <div>


### PR DESCRIPTION
App will detect network changes (change of network or change of account) and handle by reloading the page.

Updated Home page with onboarding information for metamask, matic network, etc. render Home page if no metamask browser extension detected.

`networkId` is now exposed in AppState and represents 137 for matic network, 1 for ethereum mainnet 